### PR TITLE
feat: support envelope-http

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -38,4 +38,5 @@ php:
   methodArguments: infer-optional-args
   namespace: Apideck\Unify
   outputModelSuffix: output
+  responseFormat: envelope-http
   packageName: apideck-libraries/sdk-php


### PR DESCRIPTION
This pull request includes a change to the `.speakeasy/gen.yaml` configuration file for the PHP SDK. The change adds a new configuration option to specify the response format.

Configuration update:

* [`.speakeasy/gen.yaml`](diffhunk://#diff-0f2bcc849ddce1a74ff8c03418150e851b1fb947992e6b14f76346a205806559R41): Added the `responseFormat` option with the value `envelope-http` to the PHP SDK configuration.